### PR TITLE
Fix deprecation for Symfony 4.3

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,8 +20,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('jb_phumbor');
+        if (Kernel::VERSION_ID >= 40200) {
+            $root = new TreeBuilder('jb_phumbor');
+        } else {
+            $builder = new TreeBuilder();
+            $root = $builder->root('jb_phumbor');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "jb_phumbor" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.